### PR TITLE
Fix MCP server .env loading

### DIFF
--- a/src/omni_dash/mcp/server.py
+++ b/src/omni_dash/mcp/server.py
@@ -19,9 +19,16 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+from pathlib import Path
 from typing import Any
 
+from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+
+# Load .env from the omni-dash project root (handles MCP subprocess CWD issues)
+_project_root = Path(__file__).resolve().parents[3]
+load_dotenv(_project_root / ".env", override=False)
 
 from omni_dash.api.client import OmniClient
 from omni_dash.api.documents import DocumentService


### PR DESCRIPTION
## Summary
- MCP subprocess spawned by Claude Code doesn't always inherit the expected CWD
- Explicitly loads `.env` from the package's project root via `python-dotenv` so credentials are always found

## Test plan
- [x] All 304 tests pass
- [x] Verified MCP tools authenticate after restart (`list_folders` returns data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)