### PR TITLE
Fix data discovery and query pipeline for live Omni API

### DIFF
--- a/src/omni_dash/config.py
+++ b/src/omni_dash/config.py
@@ -47,6 +47,11 @@ class OmniDashSettings(BaseSettings):
         Field(default="", description="Comma-separated additional template directories"),
     ] = ""
 
+    # Omni shared model ID (auto-discovered from dashboards if not set)
+    omni_shared_model_id: Annotated[
+        str, Field(default="", description="Omni shared model ID for topic/field discovery")
+    ] = ""
+
     # AI (Claude) integration
     anthropic_api_key: Annotated[
         str, Field(default="", description="Anthropic API key for AI dashboard generation", repr=False)

--- a/tests/test_api/test_models.py
+++ b/tests/test_api/test_models.py
@@ -7,8 +7,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from omni_dash.api.models import ModelService, OmniModel, TopicSummary
-from omni_dash.exceptions import ModelNotFoundError
+from omni_dash.api.models import ModelService, OmniModel, TopicDetail, TopicSummary
+from omni_dash.exceptions import ModelNotFoundError, OmniAPIError
 
 
 @pytest.fixture
@@ -81,17 +81,177 @@ class TestFindModelForConnection:
 
 
 class TestListTopics:
-    def test_parses_list(self, service, mock_client):
-        mock_client.get.return_value = [
-            {"name": "topic1", "label": "Topic 1", "description": "desc"},
-        ]
-        result = service.list_topics("m1")
-        assert len(result) == 1
-        assert isinstance(result[0], TopicSummary)
+    """Tests for YAML-based topic listing."""
 
-    def test_empty(self, service, mock_client):
-        mock_client.get.return_value = None
+    def test_parses_topic_files(self, service, mock_client):
+        mock_client.get.return_value = {
+            "files": {
+                "my_topic.topic": "base_view: my_view\nlabel: My Topic\n",
+                "another.topic": "base_view: other_view\n",
+                "PUBLIC/some_view.view": "schema: PUBLIC\ntable_name: SOME_TABLE\n",
+            },
+            "viewNames": {},
+            "version": 1,
+        }
+        result = service.list_topics("m1")
+        assert len(result) == 2
+        assert isinstance(result[0], TopicSummary)
+        # Sorted alphabetically
+        assert result[0].name == "another"
+        assert result[1].name == "my_topic"
+        assert result[1].label == "My Topic"
+        assert result[1].base_view == "my_view"
+
+    def test_no_topic_files(self, service, mock_client):
+        mock_client.get.return_value = {
+            "files": {"PUBLIC/view.view": "schema: PUBLIC\n"},
+            "viewNames": {},
+            "version": 1,
+        }
         assert service.list_topics("m1") == []
+
+    def test_empty_yaml_response(self, service, mock_client):
+        mock_client.get.return_value = {"files": {}, "viewNames": {}, "version": 1}
+        assert service.list_topics("m1") == []
+
+    def test_caches_yaml(self, service, mock_client):
+        mock_client.get.return_value = {
+            "files": {"t.topic": "base_view: v\n"},
+            "viewNames": {},
+            "version": 1,
+        }
+        service.list_topics("m1")
+        service.list_topics("m1")  # Second call uses cache
+        assert mock_client.get.call_count == 1
+
+
+class TestGetTopic:
+    """Tests for YAML-based topic detail."""
+
+    def test_resolves_views_and_fields(self, service, mock_client):
+        mock_client.get.return_value = {
+            "files": {
+                "my_topic.topic": "base_view: my_view\nlabel: My Topic\njoins: {}\n",
+                "PUBLIC/my_view.view": (
+                    "schema: PUBLIC\n"
+                    "table_name: MY_TABLE\n"
+                    "dimensions:\n"
+                    "  col_a:\n"
+                    "    sql: '\"COL_A\"'\n"
+                    "  col_b:\n"
+                    "    sql: '\"COL_B\"'\n"
+                    "    label: Column B\n"
+                    "measures:\n"
+                    "  total:\n"
+                    "    sql: '\"AMOUNT\"'\n"
+                    "    aggregate_type: sum\n"
+                ),
+            },
+            "viewNames": {},
+            "version": 1,
+        }
+        result = service.get_topic("m1", "my_topic")
+        assert isinstance(result, TopicDetail)
+        assert result.name == "my_topic"
+        assert result.label == "My Topic"
+        assert result.base_view == "my_view"
+        assert len(result.views) == 1
+        assert result.views[0]["name"] == "my_view"
+
+        # Should have 3 fields (2 dimensions + 1 measure)
+        assert len(result.fields) == 3
+        dims = [f for f in result.fields if f["type"] == "dimension"]
+        measures = [f for f in result.fields if f["type"] == "measure"]
+        assert len(dims) == 2
+        assert len(measures) == 1
+        assert measures[0]["qualified_name"] == "my_topic.total"
+
+    def test_hidden_fields_excluded(self, service, mock_client):
+        mock_client.get.return_value = {
+            "files": {
+                "t.topic": "base_view: v\njoins: {}\n",
+                "v.view": (
+                    "dimensions:\n"
+                    "  visible:\n"
+                    "    sql: x\n"
+                    "  hidden_one:\n"
+                    "    sql: y\n"
+                    "    hidden: true\n"
+                ),
+            },
+            "viewNames": {},
+            "version": 1,
+        }
+        result = service.get_topic("m1", "t")
+        assert len(result.fields) == 1
+        assert result.fields[0]["name"] == "visible"
+
+    def test_topic_not_found(self, service, mock_client):
+        mock_client.get.return_value = {
+            "files": {"other.topic": "base_view: v\n"},
+            "viewNames": {},
+            "version": 1,
+        }
+        with pytest.raises(OmniAPIError, match="Topic not found"):
+            service.get_topic("m1", "nonexistent")
+
+    def test_joined_views_included(self, service, mock_client):
+        mock_client.get.return_value = {
+            "files": {
+                "t.topic": "base_view: base_v\njoins:\n  joined_v: {}\n",
+                "base_v.view": "dimensions:\n  a:\n    sql: x\n",
+                "PUBLIC/joined_v.view": "dimensions:\n  b:\n    sql: y\n",
+            },
+            "viewNames": {},
+            "version": 1,
+        }
+        result = service.get_topic("m1", "t")
+        assert len(result.views) == 2
+        # Fields from both views
+        field_names = [f["name"] for f in result.fields]
+        assert "a" in field_names
+        assert "b" in field_names
+
+
+class TestListViews:
+    def test_lists_views_from_yaml(self, service, mock_client):
+        mock_client.get.return_value = {
+            "files": {},
+            "viewNames": {
+                "PUBLIC/mart_seo.view": "mart_seo",
+                "MONGO_LINDY/users.view": "mongo_lindy__users",
+            },
+            "version": 1,
+        }
+        result = service.list_views("m1")
+        assert len(result) == 2
+        # Sorted by name
+        assert result[0]["name"] == "mart_seo"
+        assert result[0]["schema"] == "PUBLIC"
+        assert result[1]["name"] == "mongo_lindy__users"
+        assert result[1]["schema"] == "MONGO_LINDY"
+
+
+class TestFindViewForTable:
+    def test_finds_view_by_name(self, service, mock_client):
+        mock_client.get.return_value = {
+            "files": {},
+            "viewNames": {
+                "PUBLIC/mart_seo.view": "mart_seo",
+            },
+            "version": 1,
+        }
+        result = service.find_view_for_table("m1", "mart_seo")
+        assert result == "mart_seo"
+
+    def test_returns_none_when_not_found(self, service, mock_client):
+        mock_client.get.return_value = {
+            "files": {},
+            "viewNames": {"PUBLIC/other.view": "other"},
+            "version": 1,
+        }
+        result = service.find_view_for_table("m1", "nonexistent")
+        assert result is None
 
 
 class TestCache:

--- a/tests/test_api/test_queries.py
+++ b/tests/test_api/test_queries.py
@@ -35,8 +35,8 @@ def test_sort():
         .build()
     )
     assert len(query.sorts) == 1
-    assert query.sorts[0]["columnName"] == "tbl.col1"
-    assert query.sorts[0]["sortDescending"] is True
+    assert query.sorts[0]["column_name"] == "tbl.col1"
+    assert query.sorts[0]["sort_descending"] is True
 
 
 def test_filter():
@@ -87,7 +87,7 @@ def test_to_api_dict():
         .limit(10)
         .to_api_dict()
     )
-    assert payload["modelId"] == "model-123"
+    assert payload["query"]["modelId"] == "model-123"
     assert payload["query"]["table"] == "tbl"
     assert payload["query"]["limit"] == 10
     assert len(payload["query"]["fields"]) == 2

--- a/tests/test_mcp/test_server.py
+++ b/tests/test_mcp/test_server.py
@@ -239,8 +239,8 @@ class TestListTopics:
         from omni_dash.api.models import TopicSummary
 
         mock_model_svc.list_topics.return_value = [
-            TopicSummary(name="mart_seo", label="SEO", description="SEO data"),
-            TopicSummary(name="mart_paid", label="Paid", description="Paid data"),
+            TopicSummary(name="mart_seo", label="SEO", description="SEO data", base_view="mart_seo_view"),
+            TopicSummary(name="mart_paid", label="Paid", description="Paid data", base_view="mart_paid_view"),
         ]
 
         result = json.loads(mcp_server.list_topics())


### PR DESCRIPTION
## Summary
- Replace broken `/api/v1/models/:id/topics` endpoint with YAML-based discovery using `/api/v1/models/:id/yaml`
- Fix query execution pipeline: NDJSON response parsing, Apache Arrow result decoding, correct payload structure
- Add `OMNI_SHARED_MODEL_ID` config field for topic/field discovery
- Normalize sort key formats (snake_case for Omni API, accept camelCase from users)

## Changes
- **`api/models.py`**: Rewrite `list_topics()` and `get_topic()` to parse `.topic` and `.view` YAML files. Add `list_views()` and `_fetch_model_yaml()` with caching.
- **`api/client.py`**: Add `post_ndjson()` method for NDJSON response handling with soft rate limit retry
- **`api/queries.py`**: Fix `modelId` nesting in payload, add Arrow result decoding via pyarrow, snake_case sort keys
- **`config.py`**: Add `omni_shared_model_id` setting
- **`mcp/server.py`**: Normalize sort keys, update topic tool responses with `base_view` and `field_count`
- **Tests**: 337 tests passing, comprehensive coverage for YAML-based discovery

## Test plan
- [x] All 337 unit tests pass
- [x] Live `list_topics()` returns 11 topics from Omni
- [x] Live `get_topic()` resolves views and fields (375 fields for fct_customer_daily_ts)
- [x] Live query returns real data from Snowflake via Omni

🤖 Generated with [Claude Code](https://claude.com/claude-code)