### PR TITLE
Fix import response parsing for dashboard ID

### DIFF
--- a/src/omni_dash/api/documents.py
+++ b/src/omni_dash/api/documents.py
@@ -250,9 +250,22 @@ class DocumentService:
         if not result or not isinstance(result, dict):
             raise OmniAPIError(0, "Empty response from dashboard import")
 
+        # The import response nests IDs under 'workbook':
+        #   workbook.identifier = short hex ID (e.g., "18a2f36a")
+        #   workbook.name = dashboard name
+        #   workbook.documentId = full UUID
+        wb = result.get("workbook", {})
+        doc_id = (
+            wb.get("identifier", "")
+            or result.get("identifier", "")
+            or result.get("id", "")
+            or result.get("documentId", "")
+        )
+        doc_name = wb.get("name", "") or result.get("name", "") or name or ""
+
         return ImportResponse(
-            document_id=result.get("identifier", result.get("id", result.get("documentId", ""))),
-            name=result.get("name", name or ""),
+            document_id=doc_id,
+            name=doc_name,
             success=True,
         )
 


### PR DESCRIPTION
## Summary
- Fix `DocumentService.import_dashboard()` to extract dashboard ID from `workbook.identifier` instead of top-level fields
- The Omni import API (`/api/unstable/documents/import`) nests the short hex ID under `workbook.identifier`, not at the response root
- This caused clone, move, and update-by-name operations to return empty `dashboard_id` values

## Test plan
- [x] 337 unit tests pass
- [x] Live import returns correct ID (e.g., `0226be32`)
- [x] Live clone/update now work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)