### PR TITLE
Fix date_range filter: use PAST instead of BETWEEN with 'now'

### DIFF
--- a/src/omni_dash/dashboard/serializer.py
+++ b/src/omni_dash/dashboard/serializer.py
@@ -93,13 +93,16 @@ def _to_omni_filter(f: FilterSpec) -> dict[str, Any]:
 
     # Map common operator names to Omni's kind/type system
     if op in ("date_range", "between", "date_between"):
+        val_str = str(value) if value else "12 complete weeks ago"
+        # Extract the interval portion: "12 complete weeks ago" → "12 complete weeks"
+        interval = val_str.replace("ago", "").strip() if "ago" in val_str else val_str
         return {
-            "kind": "BETWEEN",
+            "kind": "TIME_FOR_INTERVAL_DURATION",
             "type": "date",
-            "ui_type": "BETWEEN",
+            "ui_type": "PAST",
             "isFiscal": False,
-            "left_side": str(value) if value else "this year",
-            "right_side": "now",
+            "left_side": val_str,
+            "right_side": interval,
             "is_negative": False,
         }
     elif op in ("before", "date_before"):
@@ -206,13 +209,15 @@ def _to_omni_filter_from_dashboard(dash_filter: DashboardFilter) -> dict[str, An
     value = dash_filter.default_value
 
     if ft == "date_range":
+        val_str = str(value) if value else "12 complete weeks ago"
+        interval = val_str.replace("ago", "").strip() if "ago" in val_str else val_str
         return {
-            "kind": "BETWEEN",
+            "kind": "TIME_FOR_INTERVAL_DURATION",
             "type": "date",
-            "ui_type": "BETWEEN",
+            "ui_type": "PAST",
             "isFiscal": False,
-            "left_side": str(value) if value else "this year",
-            "right_side": "now",
+            "left_side": val_str,
+            "right_side": interval,
             "is_negative": False,
         }
     elif ft == "select":

--- a/tests/test_dashboard/test_serializer.py
+++ b/tests/test_dashboard/test_serializer.py
@@ -458,7 +458,7 @@ def test_dashboard_filters_applied_to_matching_tiles():
     for qp in payload["queryPresentations"]:
         filters = qp["query"].get("filters", {})
         assert "my_table.date" in filters
-        assert filters["my_table.date"]["kind"] == "BETWEEN"
+        assert filters["my_table.date"]["kind"] == "TIME_FOR_INTERVAL_DURATION"
         assert filters["my_table.date"]["type"] == "date"
 
 
@@ -894,7 +894,7 @@ def test_dashboard_filter_config_in_payload():
     fc = payload["filterConfig"][fid]
     assert fc["fieldName"] == "t.date"
     assert fc["label"] == "Date Filter"
-    assert fc["kind"] == "BETWEEN"
+    assert fc["kind"] == "TIME_FOR_INTERVAL_DURATION"
     assert fc["type"] == "date"
 
 


### PR DESCRIPTION
## Summary
- Omni rejects `"right_side": "now"` as an invalid literal in `BETWEEN` filters
- Changed `date_range` filters to use `TIME_FOR_INTERVAL_DURATION` with `ui_type: "PAST"` — matching real Omni dashboard fixtures (paid search, WBR)
- Fixed in both `_to_omni_filter` (tile-level) and `_to_omni_filter_from_dashboard` (dashboard-level)

## Test plan
- [x] 340 tests passing (2 assertions updated)
- [ ] Live E2E: recreate dashboard with date filter after MCP restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)