### PR TITLE
Fix vis config persistence via export→reimport flow

### DIFF
--- a/src/omni_dash/dashboard/serializer.py
+++ b/src/omni_dash/dashboard/serializer.py
@@ -732,21 +732,21 @@ class DashboardSerializer:
 
             # Visualization config — use rich Omni visTypes when appropriate
             if is_vegalite:
-                qp["visualization"] = _build_vegalite_vis(tile)
+                qp["visConfig"] = _build_vegalite_vis(tile)
             elif is_kpi:
-                qp["visualization"] = _build_kpi_vis(tile)
+                qp["visConfig"] = _build_kpi_vis(tile)
             elif is_markdown:
-                qp["visualization"] = _build_markdown_vis(tile)
+                qp["visConfig"] = _build_markdown_vis(tile)
             elif is_table:
-                qp["visualization"] = _build_table_vis(tile)
+                qp["visConfig"] = _build_table_vis(tile)
             elif is_heatmap:
-                qp["visualization"] = {
+                qp["visConfig"] = {
                     "visType": "basic",
                     "chartType": "heatmap",
                     "spec": _build_heatmap_spec(tile),
                 }
             elif omni_chart_type in _CARTESIAN_CHART_TYPES and _has_advanced_vis(tile):
-                qp["visualization"] = {
+                qp["visConfig"] = {
                     "visType": "basic",
                     "chartType": omni_chart_type,
                     "spec": _build_cartesian_spec(tile, omni_chart_type, fields),
@@ -780,7 +780,7 @@ class DashboardSerializer:
                     vis["config"]["seriesColors"] = tile.vis_config.series_colors
                 if tile.vis_config.custom:
                     vis["config"].update(tile.vis_config.custom)
-                qp["visualization"] = vis
+                qp["visConfig"] = vis
 
             # Position (layout)
             if tile.position:

--- a/tests/test_dashboard/test_serializer.py
+++ b/tests/test_dashboard/test_serializer.py
@@ -351,7 +351,7 @@ def test_cartesian_spec_generated_for_line_chart():
         ],
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    vis = payload["queryPresentations"][0]["visualization"]
+    vis = payload["queryPresentations"][0]["visConfig"]
 
     assert vis["visType"] == "basic"
     assert vis["chartType"] == "line"
@@ -377,7 +377,7 @@ def test_kpi_vis_generates_markdown_config():
         .build()
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    vis = payload["queryPresentations"][0]["visualization"]
+    vis = payload["queryPresentations"][0]["visConfig"]
 
     assert vis["visType"] == "omni-kpi"
     assert vis["chartType"] == "kpi"
@@ -399,7 +399,7 @@ def test_kpi_with_sparkline():
         .build()
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    mc = payload["queryPresentations"][0]["visualization"]["spec"]["markdownConfig"]
+    mc = payload["queryPresentations"][0]["visConfig"]["spec"]["markdownConfig"]
 
     assert len(mc) == 2
     assert mc[1]["type"] == "chart"
@@ -416,7 +416,7 @@ def test_markdown_tile_vis():
         .build()
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    vis = payload["queryPresentations"][0]["visualization"]
+    vis = payload["queryPresentations"][0]["visConfig"]
 
     assert vis["visType"] == "omni-markdown"
     assert vis["chartType"] == "markdown"
@@ -433,7 +433,7 @@ def test_table_vis_generates_spreadsheet_config():
         .build()
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    vis = payload["queryPresentations"][0]["visualization"]
+    vis = payload["queryPresentations"][0]["visConfig"]
 
     assert vis["visType"] == "omni-table"
     assert vis["chartType"] == "table"
@@ -487,7 +487,7 @@ def test_series_config_dual_axis():
         ],
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    vis = payload["queryPresentations"][0]["visualization"]
+    vis = payload["queryPresentations"][0]["visConfig"]
     spec = vis["spec"]
 
     assert vis["visType"] == "basic"
@@ -510,7 +510,7 @@ def test_value_format_in_kpi():
         .build()
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    mc = payload["queryPresentations"][0]["visualization"]["spec"]["markdownConfig"]
+    mc = payload["queryPresentations"][0]["visConfig"]["spec"]["markdownConfig"]
     assert mc[0]["config"]["field"]["format"] == "USDCURRENCY_0"
     assert mc[0]["config"]["field"]["label"]["value"] == "Total Rev"
 
@@ -525,7 +525,7 @@ def test_basic_vis_used_when_no_advanced_config():
         .build()
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    vis = payload["queryPresentations"][0]["visualization"]
+    vis = payload["queryPresentations"][0]["visConfig"]
     assert vis["visType"] == "basic"
 
 
@@ -550,7 +550,7 @@ def test_reference_lines_in_cartesian_spec():
         ],
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    vis = payload["queryPresentations"][0]["visualization"]
+    vis = payload["queryPresentations"][0]["visConfig"]
     spec = vis["spec"]
 
     assert vis["visType"] == "basic"
@@ -577,7 +577,7 @@ def test_heatmap_generates_heatmap_spec():
         .build()
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    vis = payload["queryPresentations"][0]["visualization"]
+    vis = payload["queryPresentations"][0]["visConfig"]
 
     assert vis["visType"] == "basic"
     assert vis["chartType"] == "heatmap"
@@ -606,7 +606,7 @@ def test_vegalite_tile_generates_vegalite_vis():
         .build()
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    vis = payload["queryPresentations"][0]["visualization"]
+    vis = payload["queryPresentations"][0]["visConfig"]
 
     assert vis["visType"] == "vegalite"
     assert vis["chartType"] == "code"
@@ -642,7 +642,7 @@ def test_color_values_in_cartesian_spec():
         ],
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    spec = payload["queryPresentations"][0]["visualization"]["spec"]
+    spec = payload["queryPresentations"][0]["visConfig"]["spec"]
 
     assert spec["color"]["field"]["name"] == "t.type"
     assert spec["color"]["manual"] is True
@@ -760,7 +760,7 @@ def test_frozen_column_in_table_vis():
         .build()
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    spec = payload["queryPresentations"][0]["visualization"]["spec"]
+    spec = payload["queryPresentations"][0]["visConfig"]["spec"]
     assert spec["frozenColumn"] == "t.id"
 
 
@@ -800,7 +800,7 @@ def test_data_labels_in_series_config():
         ],
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    series = payload["queryPresentations"][0]["visualization"]["spec"]["series"]
+    series = payload["queryPresentations"][0]["visConfig"]["spec"]["series"]
 
     assert series[0]["dataLabel"]["enabled"] is True
     assert series[0]["dataLabel"]["format"] == "PERCENT_1"
@@ -823,7 +823,7 @@ def test_kpi_comparison_swap_colors():
         .build()
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    mc = payload["queryPresentations"][0]["visualization"]["spec"]["markdownConfig"]
+    mc = payload["queryPresentations"][0]["visConfig"]["spec"]["markdownConfig"]
 
     assert len(mc) == 2
     assert mc[1]["type"] == "comparison"
@@ -866,7 +866,7 @@ def test_markdown_fields_are_fully_qualified():
         ],
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    vis = payload["queryPresentations"][0]["visualization"]
+    vis = payload["queryPresentations"][0]["visConfig"]
 
     assert vis["visType"] == "omni-markdown"
     assert vis["chartType"] == "markdown"
@@ -926,7 +926,7 @@ def test_vegalite_fields_included():
         ],
     )
     payload = DashboardSerializer.to_omni_create_payload(definition)
-    vis = payload["queryPresentations"][0]["visualization"]
+    vis = payload["queryPresentations"][0]["visConfig"]
 
     assert vis["fields"] == ["t.week", "t.category", "t.value"]
     assert vis["spec"]["mark"] == "bar"


### PR DESCRIPTION
## Summary
- Omni's create endpoint (`POST /api/v1/documents`) **ignores** `visConfig` in queryPresentations — all tiles get `visType: null`, `spec: {}`, `fields: []`
- The import endpoint (`POST /api/unstable/documents/import`) **does** honor visConfigs from export payloads
- New `_create_with_vis_configs` helper implements the create→export→patch→reimport pattern:
  1. Strip vis configs from payload, create skeleton dashboard
  2. Export the skeleton
  3. Inject vis configs into the export (removing stale `jsonHash`)
  4. Reimport with patched vis configs
  5. Delete the skeleton
- All 3 dashboard-creating tools (`create_dashboard`, `update_dashboard`, `add_tiles_to_dashboard`) now use this helper
- Serializer key renamed from `visualization` to `visConfig` to match Omni internals

## Test plan
- [x] 340 unit tests passing
- [x] Verified via debug script: import preserves visType, spec, fields when jsonHash is removed
- [ ] Live E2E: restart MCP server, create complex dashboard, verify tiles render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)