### PR TITLE
Fix serializer edge cases for reliable chart rendering

### DIFF
--- a/src/omni_dash/mcp/server.py
+++ b/src/omni_dash/mcp/server.py
@@ -185,7 +185,10 @@ def _create_with_vis_configs(
             existing_vc = qp_data.get("visConfig", {})
             existing_vc["visType"] = vc_patch.get("visType")
             existing_vc["chartType"] = vc_patch.get("chartType", existing_vc.get("chartType"))
-            existing_vc["spec"] = vc_patch.get("spec", {})
+            if "spec" in vc_patch:
+                existing_vc["spec"] = vc_patch["spec"]
+            if "config" in vc_patch:
+                existing_vc["config"] = vc_patch["config"]
             if vc_patch.get("fields"):
                 existing_vc["fields"] = vc_patch["fields"]
             existing_vc.pop("jsonHash", None)


### PR DESCRIPTION
## Summary
- **Remove `_has_advanced_vis()` gate**: All cartesian charts now get a proper `spec` with `configType: "cartesian"`. Previously, simple charts (area with only x_axis/y_axis) fell to a basic `config` path that the MCP patching code discarded, causing "No chart available"
- **Auto-generate series entries**: When no `series_config` is provided, series entries are auto-generated from query fields with `yAxis: "y"` and the chart's mark type, so Omni can assign fields to axes
- **Default `yAxis: "y"` in series entries**: Prevents "This chart needs a little help" errors where Omni couldn't map fields to axes
- **Auto-derive stacking from chart type**: `stacked_bar` and `stacked_area` now auto-set `stackMultiMark: true` and y-axis color stacking without requiring explicit `stacked: true`
- **Handle both `spec` and `config` keys in MCP patching**: Safety net in `_create_with_vis_configs` to copy whichever key the serializer produces

## Test plan
- [x] `uv run pytest` — 344 tests pass, 0 failures
- [x] 5 new test cases: area chart spec, stacked bar auto-stacking, series yAxis default, auto-series generation, simple chart cartesian spec
- [ ] Live E2E: create dashboard with area chart, stacked bar, and KPI tiles via MCP — verify all render correctly in Omni

---
Generated with Claude Code