### PR TITLE
Fix 5 systemic bugs for first-try dashboard correctness

### DIFF
--- a/src/omni_dash/ai/omni_adapter.py
+++ b/src/omni_dash/ai/omni_adapter.py
@@ -46,7 +46,7 @@ class OmniModelAdapter:
 
     def get_model(self, name: str) -> DbtModelMetadata:
         """Get topic detail as DbtModelMetadata with columns."""
-        detail: TopicDetail = self._model_svc.get_topic_fields(self._model_id, name)
+        detail: TopicDetail = self._model_svc.get_topic(self._model_id, name)
         columns = [
             DbtColumnMetadata(
                 name=f.get("name", ""),

--- a/src/omni_dash/dashboard/definition.py
+++ b/src/omni_dash/dashboard/definition.py
@@ -174,6 +174,15 @@ class TileQuery(BaseModel):
 class TileVisConfig(BaseModel):
     """Visualization configuration for a tile."""
 
+    @model_validator(mode="before")
+    @classmethod
+    def _alias_color(cls, values: Any) -> Any:
+        """Accept ``color`` as an alias for ``color_by``."""
+        if isinstance(values, dict):
+            if "color" in values and "color_by" not in values:
+                values["color_by"] = values.pop("color")
+        return values
+
     # Core axis & display
     x_axis: str | None = None
     y_axis: list[str] = Field(default_factory=list)
@@ -217,6 +226,7 @@ class TileVisConfig(BaseModel):
     kpi_label: str | None = None  # Override display label
     kpi_sparkline: bool = False  # Show sparkline in KPI tile
     kpi_sparkline_type: str | None = None  # "bar" or "line"
+    kpi_field: str | None = None  # Explicit field for KPI value (overrides auto-detect)
 
     # Markdown tile content
     markdown_template: str | None = None  # Raw markdown/HTML with Mustache syntax


### PR DESCRIPTION
## Summary

- **Auto-series**: exclude pivot/color_by fields from auto-generated y-axis series — fixes stacked bars showing dimension as a measure
- **KPI field selection**: smart heuristic picks measure over dimension (e.g. `total_visits_count` over `week_start`) with explicit `kpi_field` override
- **Cross-table filter propagation**: single dashboard filter now remaps across tables by matching column names (e.g. `funnel.week` → `llm.week`)
- **Method name fix**: `get_topic_fields` → `get_topic` in 4 call sites + `profile_data` fallback for non-topic Snowflake views
- **Color alias**: Pydantic `model_validator` accepts `color` as alias for `color_by` in vis_config dicts

## Test plan

- [x] 412 tests passing (13 new covering all 5 bugs)
- [ ] Live test: create stacked bar with `color_by` + `pivots` — verify color renders correctly on first try
- [ ] Live test: create KPI with date + measure fields — verify measure is displayed
- [ ] Live test: create multi-table dashboard with single date filter — verify all tiles filtered
- [ ] Live test: call `profile_data` on non-topic Snowflake view — verify fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)